### PR TITLE
a few more states addition proposal

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,18 @@ func main() {
             log.Printf("STATE is Starting")
         case sshtun.StateStarted:
             log.Printf("STATE is Started")
+        case sshtun.StateAccepted:
+            log.Printf("STATE is Accepted")
+        case sshtun.StateOpen:
+            log.Printf("STATE is Open")
+        case sshtun.StateClosed:
+            log.Printf("STATE is Closed")
+        case sshtun.StateFailed:
+            log.Printf("STATE is Failed")
+        case sshtun.StateRemoteDropped:
+            log.Printf("STATE is Dropped")
         case sshtun.StateStopped:
-            log.Printf("STATE is Stopped")
+        log.Printf("STATE is Stopped")
         }
     })
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ func main() {
         case sshtun.StateRemoteDropped:
             log.Printf("STATE is Dropped")
         case sshtun.StateStopped:
-        log.Printf("STATE is Stopped")
+            log.Printf("STATE is Stopped")
         }
     })
 

--- a/example/example.go
+++ b/example/example.go
@@ -8,7 +8,7 @@ import (
 )
 
 func main() {
-	// We want to connect to port 8080 on our machine to acces port 80 on my.super.host.com
+	// We want to connect to port 8080 on our machine to access port 80 on my.super.host.com
 	sshTun := sshtun.New(8080, "my.super.host.com", 80)
 
 	// We enable debug messages to see what happens
@@ -27,18 +27,18 @@ func main() {
 	})
 
 	// We set a callback to know the state of the forwarded connections
-	sshTun.SetForwardedConnState(func(tun *sshtun.SSHTun, state sshtun.ForwardedConnState) {
+	sshTun.SetForwardedConnState(func(tun *sshtun.SSHTun, state sshtun.ForwardedConnState, forwardCounter int) {
 		switch state {
 		case sshtun.StateAccepted:
-			log.Printf("Forward STATE is Accepted")
+			log.Printf("Forward %d STATE is Accepted", forwardCounter)
 		case sshtun.StateOpen:
-			log.Printf("Forward STATE is Open")
+			log.Printf("Forward %d STATE is Open", forwardCounter)
 		case sshtun.StateClosed:
-			log.Printf("Forward STATE is Closed")
+			log.Printf("Forward %d STATE is Closed", forwardCounter)
 		case sshtun.StateFailed:
-			log.Printf("Forward STATE is Failed")
+			log.Printf("Forward %d STATE is Failed", forwardCounter)
 		case sshtun.StateRemoteDropped:
-			log.Printf("Forward STATE is Dropped")
+			log.Printf("Forward %d STATE is Dropped", forwardCounter)
 		}
 	})
 

--- a/example/example.go
+++ b/example/example.go
@@ -26,6 +26,22 @@ func main() {
 		}
 	})
 
+	// We set a callback to know the state of the forwarded connections
+	sshTun.SetForwardedConnState(func(tun *sshtun.SSHTun, state sshtun.ForwardedConnState) {
+		switch state {
+		case sshtun.StateAccepted:
+			log.Printf("Forward STATE is Accepted")
+		case sshtun.StateOpen:
+			log.Printf("Forward STATE is Open")
+		case sshtun.StateClosed:
+			log.Printf("Forward STATE is Closed")
+		case sshtun.StateFailed:
+			log.Printf("Forward STATE is Failed")
+		case sshtun.StateRemoteDropped:
+			log.Printf("Forward STATE is Dropped")
+		}
+	})
+
 	// We start the tunnel (and restart it every time it is stopped)
 	go func() {
 		for {

--- a/sshtun.go
+++ b/sshtun.go
@@ -498,7 +498,6 @@ func (tun *SSHTun) forward(localConn net.Conn, config *ssh.ClientConfig) {
 	myCtx, myCancel := context.WithCancel(tun.ctx)
 	
 	go func() {
-		// check if connection is still alive
 		err := sshConn.Wait()
 		if err != nil {
 			if tun.debug {

--- a/sshtun.go
+++ b/sshtun.go
@@ -112,7 +112,6 @@ const (
 	// This state is the real remote server connection drop, not internal procedure of the package.
 	StateRemoteDropped
 )
-)
 
 // New creates a new SSH tunnel to the specified server redirecting a port on local localhost to a port on remote localhost.
 // By default the SSH connection is made to port 22 as root and using automatic detection of the authentication

--- a/sshtun.go
+++ b/sshtun.go
@@ -252,8 +252,8 @@ func (tun *SSHTun) SetConnState(connStateFun func(*SSHTun, ConnState)) {
 	tun.connState = connStateFun
 }
 
-// SetConnState specifies an optional callback function that is called when a SSH tunnel changes state.
-// See the ConnState type and associated constants for details.
+// SetForwardedConnState specifies an optional callback function that is called when a forwarded connection changes state.
+// See the ForwardedConnState type and associated constants for details.
 func (tun *SSHTun) SetForwardedConnState(forwardedConnState func(*SSHTun, ForwardedConnState)) {
 	tun.forwardedConnState = forwardedConnState
 }

--- a/sshtun.go
+++ b/sshtun.go
@@ -94,7 +94,7 @@ const (
 	// A call to stop or an error will make the state to transition to StateStopped.
 	StateStarted
 	
-		// StateAccepted represents a (local) listener connection. This state gets triggered when a new incoming connection is made.
+	// StateAccepted represents a (local) listener connection. This state gets triggered when a new incoming connection is made.
 	StateAccepted
 
 	// StateOpen represents the last part of a successful remote connection proccess.


### PR DESCRIPTION
Hi Roger,

I found this little package extremely useful and would like to contribute with some low hanging fruits that I anyway coded for my project and PR it back :)

More specifically I added 5 more states

```go
	// StateAccepted represents a (local) listener connection. This state gets triggered when a new incoming connection is made.
	StateAccepted

	// StateOpen represents the last part of a successful remote connection proccess.
	// This state's purpose is to signal when the connection is established and fully usable.
	StateOpen

	// StateClosed represents a finished connection cycle as an internal proccess of the package.
	// When triggered it means a successful connection has been terminated.
	StateClosed

	// StateFailed represents a remote dial to server failure, while the underline SSH connection is established.
	StateFailed

	// StateRemoteDropped represents a shut down SSH connection from server.
	// This state is the real remote server connection drop, not internal procedure of the package.
	StateRemoteDropped
``` 

I also included a check for connection drop from remote

```go
	go func() {
		// check if connection is still alive
		err := sshConn.Wait()
		if err != nil {
			if tun.debug {
				log.Printf("SSH connection to %s has shut down: %s", server, err.Error())
			}
		}
		if tun.connState != nil {
			tun.connState(tun, StateRemoteDropped)
		}
	}()
```

thanks in advance,
Byron