### PR TITLE
Fixed: io.Copy() blocking indefinitly when chaining tunnels

### DIFF
--- a/example/example.go
+++ b/example/example.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/rgzr/sshtun"
+	"github.com/stankovic-marko/sshtun"
 )
 
 func main() {

--- a/forward.go
+++ b/forward.go
@@ -85,10 +85,6 @@ func (tun *SSHTun) forward(localConn net.Conn) {
 	})
 
 	err = errGroup.Wait()
-	tun.tunneledState(&TunneledConnState{
-		Ready:  false,
-		Closed: true,
-	})
 
 	<-connCtx.Done()
 
@@ -105,8 +101,10 @@ func (tun *SSHTun) forward(localConn net.Conn) {
 	}
 
 	tun.tunneledState(&TunneledConnState{
-		From: from,
-		Info: fmt.Sprintf("connection closed: %s", connStr),
+		From:   from,
+		Info:   fmt.Sprintf("connection closed: %s", connStr),
+		Ready:  false,
+		Closed: true,
 	})
 }
 

--- a/forward.go
+++ b/forward.go
@@ -85,6 +85,10 @@ func (tun *SSHTun) forward(localConn net.Conn) {
 	})
 
 	err = errGroup.Wait()
+	tun.tunneledState(&TunneledConnState{
+		Ready:  false,
+		Closed: true,
+	})
 
 	<-connCtx.Done()
 
@@ -93,9 +97,8 @@ func (tun *SSHTun) forward(localConn net.Conn) {
 	default:
 		if err != nil {
 			tun.tunneledState(&TunneledConnState{
-				From:   from,
-				Error:  err,
-				Closed: true,
+				From:  from,
+				Error: err,
 			})
 		}
 	}

--- a/forward.go
+++ b/forward.go
@@ -93,9 +93,8 @@ func (tun *SSHTun) forward(localConn net.Conn) {
 	default:
 		if err != nil {
 			tun.tunneledState(&TunneledConnState{
-				From:   from,
-				Error:  err,
-				Closed: true,
+				From:  from,
+				Error: err,
 			})
 		}
 	}

--- a/forward.go
+++ b/forward.go
@@ -19,6 +19,8 @@ type TunneledConnState struct {
 	Error error
 	// Ready indicates if the connection is established.
 	Ready bool
+	// Closed indicates if the coonnection is closed.
+	Closed bool
 }
 
 func (s *TunneledConnState) String() string {
@@ -55,9 +57,10 @@ func (tun *SSHTun) forward(localConn net.Conn) {
 		tun.server.String(), tun.remote.Type(), tun.remote.String())
 
 	tun.tunneledState(&TunneledConnState{
-		From:  from,
-		Info:  fmt.Sprintf("connection established: %s", connStr),
-		Ready: true,
+		From:   from,
+		Info:   fmt.Sprintf("connection established: %s", connStr),
+		Ready:  true,
+		Closed: false,
 	})
 
 	connCtx, connCancel := context.WithCancel(tun.ctx)
@@ -90,8 +93,9 @@ func (tun *SSHTun) forward(localConn net.Conn) {
 	default:
 		if err != nil {
 			tun.tunneledState(&TunneledConnState{
-				From:  from,
-				Error: err,
+				From:   from,
+				Error:  err,
+				Closed: true,
 			})
 		}
 	}

--- a/forward.go
+++ b/forward.go
@@ -97,8 +97,9 @@ func (tun *SSHTun) forward(localConn net.Conn) {
 	default:
 		if err != nil {
 			tun.tunneledState(&TunneledConnState{
-				From:  from,
-				Error: err,
+				From:   from,
+				Error:  err,
+				Closed: true,
 			})
 		}
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/rgzr/sshtun
+module github.com/stankovic-marko/sshtun
 
 go 1.19
 


### PR DESCRIPTION
When chaining tunnels, io.Copy() on tunnels 1 and 2 never gets EOF and is blocked indefinitely. This prevents connections from closing. This also causes a number of goroutines to rise until OOM.  Also, this commit fixes errors occurring when sending HTTP requests through tunnels.
```
  ┌──────┐
  │Client│
  └───┬──┘
      │      ssh tunnel1
      │
 ┌────▼───┐
 │Tunnel 1│
 └────┬───┘
      │      ssh tunnel2
      │
 ┌────▼───┐
 │Tunnel 2│
 └────┬───┘
      │      ssh server
      │
  ┌───▼──┐
  │Server│
  └──────┘
```
If you have any questions or need further clarification, feel free to ask.